### PR TITLE
Favorites page & functionality + favorite btn functionality on feed

### DIFF
--- a/prisma/migrations/20240229200319_composite_favorite_key/migration.sql
+++ b/prisma/migrations/20240229200319_composite_favorite_key/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - The primary key for the `Favorite` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `Favorite` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Favorite" DROP CONSTRAINT "Favorite_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "Favorite_pkey" PRIMARY KEY ("userId", "listingId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,9 +56,10 @@ model Listing {
 
 // Representing the many:many relationship with users and favorited listings
 model Favorite {
-  id        Int     @id @default(autoincrement())
   user      User    @relation(fields: [userId], references: [id])
   userId    String  @db.Uuid // the ID of the user who favorited the listing
   listing   Listing @relation(fields: [listingId], references: [id])
   listingId String  @db.Uuid // the ID of the post that the user favorited
+
+  @@id([userId, listingId])
 }

--- a/src/app.css
+++ b/src/app.css
@@ -36,3 +36,19 @@ body {
 .snackbar-wrapper {
   @apply z-50 absolute left-1/2 -translate-x-1/2
 }
+
+span.reg_symbol, i.reg_symbol {
+  font-variation-settings:
+  'FILL' 0,
+  'wght' 200,
+  'GRAD' 0,
+  'opsz' 24
+}
+
+span.fill_symbol, i.fill_symbol {
+  font-variation-settings:
+  'FILL' 1,
+  'wght' 200,
+  'GRAD' 0,
+  'opsz' 24
+}

--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,7 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<link
 			rel="stylesheet"
-			href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,200,0,0"
+			href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
 		/>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/lib/components/ButtonContainer.svelte
+++ b/src/lib/components/ButtonContainer.svelte
@@ -17,7 +17,7 @@
 
 		<!--chat button-->
 		<a href="/chats">
-			<i class="material-symbols-outlined icon hover:text-slate-200">chat_bubble</i>
+			<i class="material-symbols-outlined icon reg_symbol hover:text-slate-200">chat_bubble</i>
 		</a>
 	{:else}
 		<!--sign up and login button-->
@@ -27,16 +27,16 @@
 
 	<!--profile button-->
 	<a href={getLink('/profile')}>
-		<i class="material-symbols-outlined icon hover:text-slate-200">person</i>
+		<i class="material-symbols-outlined icon reg_symbol hover:text-slate-200">person</i>
 	</a>
 
 	<!--favorites button-->
 	<a href={getLink('/favorites')}>
-		<i class="material-symbols-outlined icon hover:text-slate-200">favorite</i>
+		<i class="material-symbols-outlined icon reg_symbol hover:text-slate-200">favorite</i>
 	</a>
 
 	<!--settings button-->
 	<a href={getLink('/settings')}>
-		<i class="material-symbols-outlined icon hover:text-slate-200">settings</i>
+		<i class="material-symbols-outlined icon reg_symbol hover:text-slate-200">settings</i>
 	</a>
 </div>

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -18,7 +18,10 @@
 {#if display == 'card'}
 	<div class="relative h-min text-slate-50">
 		{#if listing.sellerId != userID}
-			<form method="POST" action="/feed?/favorite">
+			<form
+				method="POST"
+				action={`/feed?${listing.isFavoritedByCurrentUser ? '/unfavorite' : '/favorite'}`}
+			>
 				<input type="hidden" name="listing_id" value={listing.id} />
 				<button
 					class="absolute right-0 border rounded-md bg-slate-300 hover:opacity-60 border-maristdarkgrey"

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -3,6 +3,7 @@
 
 	export let listing: Listing;
 	export let display: 'row' | 'card' = 'card';
+	export let userID: string;
 
 	function favoriteListing(event: Event) {
 		event.preventDefault();
@@ -14,14 +15,16 @@
 	<div class="relative h-min text-slate-50">
 		<a href={`/${listing.id}`} class="inline-block h-full w-full">
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<span
-				on:click={favoriteListing}
-				tabindex="0"
-				role="button"
-				class="absolute text-maristred text-4xl font-bold material-symbols-outlined right-0 hover:cursor-pointer"
-			>
-				favorite
-			</span>
+			{#if listing.sellerId != userID}
+				<span
+					on:click={favoriteListing}
+					tabindex="0"
+					role="button"
+					class="absolute text-maristred text-4xl font-bold material-symbols-outlined right-0 hover:cursor-pointer"
+				>
+					favorite
+				</span>
+			{/if}
 
 			<img src={listing.imageUrl} alt="" class="aspect-square max-w-[100%]" />
 			<div class="flex pt-2 justify-between">

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -8,11 +8,6 @@
 	export let listing: ListingWithFavoriteBool;
 	export let display: 'row' | 'card' = 'card';
 	export let userID: string;
-
-	function favoriteListing(event: Event) {
-		event.preventDefault();
-		console.log('Favorite');
-	}
 </script>
 
 {#if display == 'card'}

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import type { Listing } from '@prisma/client';
 
 	interface ListingWithFavoriteBool extends Listing {
@@ -16,6 +17,7 @@
 			<form
 				method="POST"
 				action={`/feed?${listing.isFavoritedByCurrentUser ? '/unfavorite' : '/favorite'}`}
+				use:enhance
 			>
 				<input type="hidden" name="listing_id" value={listing.id} />
 				<button

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -17,11 +17,10 @@
 
 {#if display == 'card'}
 	<div class="relative h-min text-slate-50">
-		<a href={`/${listing.id}`} class="inline-block h-full w-full">
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			{#if listing.sellerId != userID}
+		{#if listing.sellerId != userID}
+			<form method="POST" action="/feed?/favorite">
+				<input type="hidden" name="listing_id" value={listing.id} />
 				<button
-					on:click={favoriteListing}
 					class="absolute right-0 border rounded-md bg-slate-300 hover:opacity-60 border-maristdarkgrey"
 				>
 					<span
@@ -32,8 +31,10 @@
 						favorite
 					</span>
 				</button>
-			{/if}
+			</form>
+		{/if}
 
+		<a href={`/${listing.id}`} class="inline-block h-full w-full">
 			<img src={listing.imageUrl} alt="" class="aspect-square max-w-[100%]" />
 			<div class="flex pt-2 justify-between">
 				<p>{listing.listingTitle}</p>

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -16,14 +16,16 @@
 		<a href={`/${listing.id}`} class="inline-block h-full w-full">
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
 			{#if listing.sellerId != userID}
-				<span
+				<button
 					on:click={favoriteListing}
-					tabindex="0"
-					role="button"
-					class="absolute text-maristred text-4xl font-bold material-symbols-outlined right-0 hover:cursor-pointer"
+					class="absolute right-0 border rounded-md bg-slate-300 hover:opacity-60 border-maristdarkgrey"
 				>
-					favorite
-				</span>
+					<span
+						class="material-symbols-outlined reg_symbol text-maristred font-bold text-3xl p-0.5"
+					>
+						favorite
+					</span>
+				</button>
 			{/if}
 
 			<img src={listing.imageUrl} alt="" class="aspect-square max-w-[100%]" />

--- a/src/lib/components/Listing.svelte
+++ b/src/lib/components/Listing.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import type { Listing } from '@prisma/client';
 
-	export let listing: Listing;
+	interface ListingWithFavoriteBool extends Listing {
+		isFavoritedByCurrentUser?: string;
+	}
+
+	export let listing: ListingWithFavoriteBool;
 	export let display: 'row' | 'card' = 'card';
 	export let userID: string;
 
@@ -21,7 +25,9 @@
 					class="absolute right-0 border rounded-md bg-slate-300 hover:opacity-60 border-maristdarkgrey"
 				>
 					<span
-						class="material-symbols-outlined reg_symbol text-maristred font-bold text-3xl p-0.5"
+						class={`material-symbols-outlined ${
+							listing.isFavoritedByCurrentUser ? 'fill_symbol' : 'reg_symbol'
+						} text-maristred font-bold text-3xl p-0.5`}
 					>
 						favorite
 					</span>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,7 +21,7 @@
 		<img src={logo} alt="The FoxMarket Logo" class="w-[250px] px-4 py-2" />
 	</a>
 	<div class="flex w-[55%] items-center">
-		<i class="material-symbols-outlined text-maristgrey absolute px-2"> search </i>
+		<i class="material-symbols-outlined reg_symbol text-maristgrey absolute px-2"> search </i>
 		<input type="search" class="input pl-10 tracking-wider font-bold" placeholder="Search" />
 	</div>
 

--- a/src/routes/[id]/+page.server.ts
+++ b/src/routes/[id]/+page.server.ts
@@ -6,6 +6,9 @@ import type { Listing } from '@prisma/client';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch, params }) => {
+	interface ListingWithFavoriteBool extends Listing {
+		isFavoritedByCurrentUser?: string;
+	}
 	const itemID = params.id;
 
 	// get the listing info
@@ -17,7 +20,7 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
 	const { username, itemsSold } = await sellerInfo.json();
 
 	return {
-		theItem: item as Listing,
+		theItem: item as ListingWithFavoriteBool,
 		sellerUsername: username as string,
 		sellerItemsSold: itemsSold as number,
 	};

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -56,7 +56,11 @@
 						I'm Interested
 					</button>
 
-					<form method="POST" action="/feed?/favorite" use:enhance={submitForm}>
+					<form
+						method="POST"
+						action={`/feed?${item.isFavoritedByCurrentUser ? '/unfavorite' : '/favorite'}`}
+						use:enhance={submitForm}
+					>
 						<input type="hidden" name="listing_id" value={item.id} />
 						<button
 							class={`btn py-2 !border-2 text-xl font-bold ${

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -40,7 +40,7 @@
 						<span
 							tabindex="0"
 							role="button"
-							class="text-maristred text-2xl font-bold material-symbols-outlined hover:cursor-pointer pr-2"
+							class="text-maristred text-2xl font-bold material-symbols-outlined reg_symbol hover:cursor-pointer pr-2"
 						>
 							favorite
 						</span>

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -27,24 +27,38 @@
 			</h1>
 
 			<div class="flex flex-col gap-2 w-full">
-				<!-- TODO: Have this button start a chat with the seller and buyer -->
-				<button
-					class="btn !border-0 py-2 bg-maristred text-xl font-bold text-slate-50 hover:opacity-70"
-				>
-					I'm Interested
-				</button>
-
-				<!-- TODO: Have this button add the listing to the user's favorites -->
-				<button class="btn py-2 !border-2 text-xl font-bold text-slate-50 hover:opacity-70">
-					<span
-						tabindex="0"
-						role="button"
-						class="text-maristred text-2xl font-bold material-symbols-outlined hover:cursor-pointer pr-2"
+				{#if item.sellerId != data.userID}
+					<!-- TODO: Have this button start a chat with the seller and buyer -->
+					<button
+						class="btn !border-0 py-2 bg-maristred text-xl font-bold text-slate-50 hover:opacity-70"
 					>
-						favorite
-					</span>
-					Favorite
-				</button>
+						I'm Interested
+					</button>
+
+					<!-- TODO: Have this button add the listing to the user's favorites -->
+					<button class="btn py-2 !border-2 text-xl font-bold text-slate-50 hover:opacity-70">
+						<span
+							tabindex="0"
+							role="button"
+							class="text-maristred text-2xl font-bold material-symbols-outlined hover:cursor-pointer pr-2"
+						>
+							favorite
+						</span>
+						Favorite
+					</button>
+				{:else}
+					<button
+						class="btn border-0 py-2 bg-maristred text-xl font-bold text-slate-50 hover:opacity-70"
+					>
+						<span
+							tabindex="0"
+							role="button"
+							class="text-slate-50 text-2xl material-symbols-outlined hover:cursor-pointer pr-2"
+						>
+							edit_note
+						</span>
+						Edit
+					</button>{/if}
 			</div>
 
 			<div class="text-slate-50 tracking-wide">

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -35,16 +35,21 @@
 						I'm Interested
 					</button>
 
-					<!-- TODO: Have this button add the listing to the user's favorites -->
-					<button class="btn py-2 !border-2 text-xl font-bold text-slate-50 hover:opacity-70">
+					<button
+						class={`btn py-2 !border-2 text-xl font-bold ${
+							item.isFavoritedByCurrentUser ? 'bg-maristgrey text-slate-950' : 'text-slate-50'
+						} hover:opacity-70`}
+					>
 						<span
 							tabindex="0"
 							role="button"
-							class="text-maristred text-2xl font-bold material-symbols-outlined reg_symbol hover:cursor-pointer pr-2"
+							class={`text-maristred text-2xl font-bold material-symbols-outlined ${
+								item.isFavoritedByCurrentUser ? 'fill_symbol' : 'reg_symbol'
+							} hover:cursor-pointer pr-2`}
 						>
 							favorite
 						</span>
-						Favorite
+						{item.isFavoritedByCurrentUser ? 'Unfavorite' : 'Favorite'}
 					</button>
 				{:else}
 					<button

--- a/src/routes/api/favorite/+server.ts
+++ b/src/routes/api/favorite/+server.ts
@@ -33,3 +33,33 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	return json({});
 };
+
+export const DELETE: RequestHandler = async ({ request }) => {
+	const { listingID, favoritingUser } = await request.json();
+
+	try {
+		await prisma.favorite.delete({
+			where: {
+				userId_listingId: {
+					userId: favoritingUser,
+					listingId: listingID,
+				},
+			},
+		});
+	} catch (err) {
+		const typedError = err as PrismaClientKnownRequestError;
+
+		// user hasn't already favorited the post
+		if (typedError.code === 'P2025') {
+			throw error(409, {
+				message: 'Listing has not been previously favorited by user.',
+			});
+		}
+
+		throw error(500, {
+			message: typedError.message,
+		});
+	}
+
+	return json({});
+};

--- a/src/routes/api/favorite/+server.ts
+++ b/src/routes/api/favorite/+server.ts
@@ -1,0 +1,35 @@
+/* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/prefer-default-export */
+
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import type { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import prisma from '$lib/utils/prismaClient';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const { listingID, favoritingUser } = await request.json();
+
+	try {
+		await prisma.favorite.create({
+			data: {
+				userId: favoritingUser,
+				listingId: listingID,
+			},
+		});
+	} catch (err) {
+		const typedError = err as PrismaClientKnownRequestError;
+
+		// user has already favorite the post
+		if (typedError.code === 'P2002') {
+			throw error(409, {
+				message: 'User has already favorited this listing.',
+			});
+		}
+
+		throw error(500, {
+			message: typedError.message,
+		});
+	}
+
+	return json({});
+};

--- a/src/routes/api/favorites/[user_id]/+server.ts
+++ b/src/routes/api/favorites/[user_id]/+server.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/prefer-default-export */
+
+import { json, type RequestHandler } from '@sveltejs/kit';
+import type { Listing } from '@prisma/client';
+import prisma from '$lib/utils/prismaClient';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const userID = params.user_id;
+	const userListings: Listing[] = [];
+
+	const userFavorites = await prisma.favorite.findMany({
+		where: { userId: userID }, // get all items that were favorited by this user
+		include: {
+			listing: true,
+		},
+	});
+
+	userFavorites.forEach((favorite) => {
+		userListings.push(favorite.listing);
+	});
+
+	return json({ listings: userListings });
+};

--- a/src/routes/api/item/[item_id]/+server.ts
+++ b/src/routes/api/item/[item_id]/+server.ts
@@ -5,14 +5,24 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import prisma from '$lib/utils/prismaClient';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
 	const itemID = params.item_id;
 
 	const item = await prisma.listing.findFirst({
 		where: {
 			id: itemID,
 		},
+		include: {
+			favoritedBy: true,
+		},
 	});
 
-	return json({ item });
+	const isFavoritedByCurrentUser = item?.favoritedBy.some(
+		(favorite) => favorite.userId.toString() === locals.data?.userID,
+	);
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { favoritedBy, ...restOfListing } = item!;
+
+	return json({ item: { ...restOfListing, isFavoritedByCurrentUser } });
 };

--- a/src/routes/api/items/+server.ts
+++ b/src/routes/api/items/+server.ts
@@ -5,10 +5,24 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import prisma from '$lib/utils/prismaClient';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ locals }) => {
 	const allListings = await prisma.listing.findMany({
 		where: { sold: false },
+		include: {
+			favoritedBy: true,
+		},
 	});
 
-	return json({ listings: allListings });
+	const listingsWithFavBool = allListings.map((listing) => {
+		const isFavoritedByCurrentUser = listing.favoritedBy.some(
+			(favorite) => favorite.userId.toString() === locals.data?.userID,
+		);
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { favoritedBy, ...restOfListing } = listing;
+
+		return { ...restOfListing, isFavoritedByCurrentUser };
+	});
+
+	return json({ listings: listingsWithFavBool });
 };

--- a/src/routes/favorites/+page.server.ts
+++ b/src/routes/favorites/+page.server.ts
@@ -2,6 +2,15 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/prefer-default-export */
 
+import type { Listing } from '@prisma/client';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {};
+export const load: PageServerLoad = async ({ fetch, locals }) => {
+	// get all the listings that were favorited by the user
+	const data = await fetch(`/api/favorites/${locals.data?.userID}`);
+	const { listings } = await data.json();
+
+	return {
+		listings: listings as Listing[],
+	};
+};

--- a/src/routes/favorites/+page.svelte
+++ b/src/routes/favorites/+page.svelte
@@ -4,6 +4,7 @@
 	import { SlideToggle } from '@skeletonlabs/skeleton';
 
 	export let data: PageData;
+	const userID = data.userID!;
 
 	$: ({ listings } = data);
 
@@ -53,6 +54,6 @@
 	</div>
 
 	{#each filteredListings as item (item.id)}
-		<Listing listing={item} display="row" />
+		<Listing listing={item} display="row" {userID} />
 	{/each}
 </div>

--- a/src/routes/favorites/+page.svelte
+++ b/src/routes/favorites/+page.svelte
@@ -33,7 +33,7 @@
 	<h1 class="text-5xl text-slate-50 py-6 font-bold tracking-wider">My Favorites</h1>
 
 	<div class="flex w-[55%] items-center gap-10">
-		<i class="material-symbols-outlined text-maristgrey absolute px-2"> search </i>
+		<i class="material-symbols-outlined reg_symbol text-maristgrey absolute px-2"> search </i>
 		<input
 			type="search"
 			class="input pl-10 tracking-wider font-bold"

--- a/src/routes/favorites/+page.svelte
+++ b/src/routes/favorites/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import Listing from '$lib/components/Listing.svelte';
+	import type { PageData } from './$types';
+	import { SlideToggle } from '@skeletonlabs/skeleton';
+
+	export let data: PageData;
+
+	$: ({ listings } = data);
+
+	$: filteredListings = listings;
+	let searchQuery = '';
+	let showSold = false;
+
+	function filterListings() {
+		filteredListings = listings.filter((item) => {
+			return (
+				item.listingTitle.toLowerCase().includes(searchQuery.trim().toLowerCase()) &&
+				item.sold == showSold
+			);
+		});
+	}
+
+	$: {
+		const searchDependency = searchQuery;
+		const soldDependency = showSold;
+
+		filterListings();
+	}
+</script>
+
+<div class="flex flex-col items-center h-screen w-full gap-2">
+	<h1 class="text-5xl text-slate-50 py-6 font-bold tracking-wider">My Favorites</h1>
+
+	<div class="flex w-[55%] items-center gap-10">
+		<i class="material-symbols-outlined text-maristgrey absolute px-2"> search </i>
+		<input
+			type="search"
+			class="input pl-10 tracking-wider font-bold"
+			placeholder="Search my items..."
+			bind:value={searchQuery}
+		/>
+
+		<div class="flex items-center gap-2">
+			<label for="soldToggle" class="text-slate-50">Sold Items</label>
+			<SlideToggle
+				id="soldToggle"
+				name="showSold"
+				bind:checked={showSold}
+				active="bg-maristred"
+				class="bg-maristgrey"
+			/>
+		</div>
+	</div>
+
+	{#each filteredListings as item (item.id)}
+		<Listing listing={item} display="row" />
+	{/each}
+</div>

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 /* eslint-disable import/extensions */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/prefer-default-export */
 
 import type { Listing } from '@prisma/client';
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch }) => {
 	const data = await fetch('/api/items');
@@ -13,3 +14,14 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		listings: listings as Listing[],
 	};
 };
+
+export const actions = {
+	favorite: async ({ request, locals }) => {
+		const data = await request.formData();
+		const listingToFavorite = data.get('listing_id') as string;
+		const favoritingUser = locals.data?.userID!;
+
+		// TODO: call favorite API here
+		console.log(listingToFavorite, favoritingUser); // temp, will remove
+	},
+} satisfies Actions;

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -4,6 +4,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import type { Listing } from '@prisma/client';
+import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch }) => {
@@ -16,12 +17,23 @@ export const load: PageServerLoad = async ({ fetch }) => {
 };
 
 export const actions = {
-	favorite: async ({ request, locals }) => {
+	favorite: async ({ request, locals, fetch }) => {
 		const data = await request.formData();
 		const listingToFavorite = data.get('listing_id') as string;
 		const favoritingUser = locals.data?.userID!;
 
-		// TODO: call favorite API here
-		console.log(listingToFavorite, favoritingUser); // temp, will remove
+		const response = await fetch('/api/favorite', {
+			method: 'POST',
+			body: JSON.stringify({
+				listingID: listingToFavorite,
+				favoritingUser,
+			}),
+		});
+
+		if (response.ok) {
+			throw redirect(302, '/feed');
+		}
+
+		return fail(response.status, { errors: [(await response.json()).message] });
 	},
 } satisfies Actions;

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -36,4 +36,24 @@ export const actions = {
 
 		return fail(response.status, { errors: [(await response.json()).message] });
 	},
+
+	unfavorite: async ({ request, locals, fetch }) => {
+		const data = await request.formData();
+		const listingToFavorite = data.get('listing_id') as string;
+		const favoritingUser = locals.data?.userID!;
+
+		const response = await fetch('/api/favorite', {
+			method: 'DELETE',
+			body: JSON.stringify({
+				listingID: listingToFavorite,
+				favoritingUser,
+			}),
+		});
+
+		if (response.ok) {
+			throw redirect(302, '/feed');
+		}
+
+		return fail(response.status, { errors: [(await response.json()).message] });
+	},
 } satisfies Actions;

--- a/src/routes/feed/+page.svelte
+++ b/src/routes/feed/+page.svelte
@@ -3,13 +3,14 @@
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+	const userID = data.userID!;
 </script>
 
 <div id="feed" class="h-[calc(100vh-56px)] flex">
 	<div id="filters" class="w-1/6">Filters</div>
 	<div id="items" class="w-full grid grid-cols-4 gap-8 px-5">
 		{#each data.listings as listing}
-			<Listing {listing} />
+			<Listing {listing} {userID} />
 		{/each}
 	</div>
 </div>

--- a/src/routes/items/+page.svelte
+++ b/src/routes/items/+page.svelte
@@ -59,7 +59,7 @@
 	<h1 class="text-5xl text-slate-50 py-6 font-bold tracking-wider">My Items</h1>
 
 	<div class="flex w-[55%] items-center gap-10">
-		<i class="material-symbols-outlined text-maristgrey absolute px-2"> search </i>
+		<i class="material-symbols-outlined reg_symbol text-maristgrey absolute px-2"> search </i>
 		<input
 			type="search"
 			class="input pl-10 tracking-wider font-bold"

--- a/src/routes/items/+page.svelte
+++ b/src/routes/items/+page.svelte
@@ -13,6 +13,7 @@
 	export let data: PageData;
 	export let form: ActionData;
 
+	const userID = data.userID!;
 	const modalStore = getModalStore();
 	const modalComponent: ModalComponent = { ref: CreateListingModal };
 	const modal: ModalSettings = {
@@ -87,6 +88,6 @@
 	</div>
 
 	{#each filteredListings as item (item.id)}
-		<Listing listing={item} display="row" />
+		<Listing listing={item} display="row" {userID} />
 	{/each}
 </div>


### PR DESCRIPTION
Resolves #24, #18 

Favorites page now shows all items that the user has favorited. Similar layout to the items page where the user can see all unsold favorited listings, and then can search in all the listings that are shown using the search bar. There is a sold toggle that the user can filter out all the favorites that were sold. 

Listings shown on the feed now have a favorite button on the top right corner, when pressed will add that listing to the user's favorite list and then update based on if the listing is favorited or not. (empty heart for not favorited, filled in heart for favorited post.

SB: User can't favorite their own posts, the favorite button is only present on other users listings.