### PR TITLE
Remove hardcoded URL

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -4,7 +4,7 @@
 	let toastStore = getToastStore();
 
 	async function logUserOut() {
-		const response = await fetch(`http://localhost:5173/api/users/logout`, {
+		const response = await fetch(`/api/users/logout`, {
 			method: 'POST',
 		});
 


### PR DESCRIPTION
- A hardcoded API url was used on the logout page, but it is now only using a relative url.

(Not sure what I was thinking before, but the relative url is working perfectly. No need for a absolute url)

Resolves #12 