### PR TITLE
Mark Item As Sold Functionality

### DIFF
--- a/src/lib/components/EditForm.svelte
+++ b/src/lib/components/EditForm.svelte
@@ -86,6 +86,7 @@
 		props: {
 			buyerList,
 			submitFunction: markAsSoldSubmit,
+			itemID: item.id
 		},
 	};
 	const modal: ModalSettings = {

--- a/src/lib/components/EditForm.svelte
+++ b/src/lib/components/EditForm.svelte
@@ -7,6 +7,7 @@
 	import BrandSearch from './BrandSearch.svelte';
 	import { getModalStore, type ModalComponent, type ModalSettings } from '@skeletonlabs/skeleton';
 	import MarkAsSoldModal from './MarkAsSoldModal.svelte';
+	import { goto } from '$app/navigation';
 
 	interface ListingWithFavoriteBool extends Listing {
 		isFavoritedByCurrentUser?: string;
@@ -74,7 +75,10 @@
 
 	const markAsSoldSubmit: SubmitFunction = () => {
 		return async ({ result }) => {
-			modalStore.close();
+			if (result.type == 'success') {
+				modalStore.close();
+				await goto('/items');
+			}
 
 			await applyAction(result);
 		};
@@ -86,7 +90,7 @@
 		props: {
 			buyerList,
 			submitFunction: markAsSoldSubmit,
-			itemID: item.id
+			itemID: item.id,
 		},
 	};
 	const modal: ModalSettings = {

--- a/src/lib/components/EditForm.svelte
+++ b/src/lib/components/EditForm.svelte
@@ -5,6 +5,8 @@
 	import type { Listing } from '@prisma/client';
 	import type { SubmitFunction } from '@sveltejs/kit';
 	import BrandSearch from './BrandSearch.svelte';
+	import { getModalStore, type ModalComponent, type ModalSettings } from '@skeletonlabs/skeleton';
+	import MarkAsSoldModal from './MarkAsSoldModal.svelte';
 
 	interface ListingWithFavoriteBool extends Listing {
 		isFavoritedByCurrentUser?: string;
@@ -14,6 +16,7 @@
 
 	export let item: ListingWithFavoriteBool;
 	export let isEditing: boolean;
+	export let buyerList: { username: string; id: string }[];
 
 	let selectedBrand = true;
 
@@ -68,9 +71,29 @@
 
 		return uneditedFieldNames;
 	}
+
+	const modalStore = getModalStore();
+	const modalComponent: ModalComponent = {
+		ref: MarkAsSoldModal,
+		props: {
+			buyerList
+		}
+	};
+	const modal: ModalSettings = {
+		type: 'component',
+		component: modalComponent,
+	};
 </script>
 
-<div class="flex items-center justify-center w-2/5">
+<div class="flex flex-col items-center justify-center w-2/5">
+	<button
+		class="w-1/3 bg-maristred border-slate-50 border mt-8 text-xl text-slate-50 py-1 hover:opacity-80 disabled:opacity-50 mb-3"
+		type="button"
+		on:click={() => modalStore.trigger(modal)}
+	>
+		Mark as Sold
+	</button>
+
 	<form
 		method="POST"
 		class="flex flex-col w-2/3 gap-8 items-center"

--- a/src/lib/components/EditForm.svelte
+++ b/src/lib/components/EditForm.svelte
@@ -72,12 +72,21 @@
 		return uneditedFieldNames;
 	}
 
+	const markAsSoldSubmit: SubmitFunction = () => {
+		return async ({ result }) => {
+			modalStore.close();
+
+			await applyAction(result);
+		};
+	};
+
 	const modalStore = getModalStore();
 	const modalComponent: ModalComponent = {
 		ref: MarkAsSoldModal,
 		props: {
-			buyerList
-		}
+			buyerList,
+			submitFunction: markAsSoldSubmit,
+		},
 	};
 	const modal: ModalSettings = {
 		type: 'component',

--- a/src/lib/components/ListingInfoDisplay.svelte
+++ b/src/lib/components/ListingInfoDisplay.svelte
@@ -89,19 +89,21 @@
 					</button>
 				</form>
 			{:else}
-				<button
-					class="btn border-0 py-2 bg-maristred text-xl font-bold text-slate-50 hover:opacity-70"
-					on:click={() => (isEditing = true)}
-				>
-					<span
-						tabindex="0"
-						role="button"
-						class="text-slate-50 text-2xl material-symbols-outlined hover:cursor-pointer pr-2"
-					>
-						edit_note
-					</span>
-					Edit
-				</button>
+				{#if !item.sold}
+					<button
+						class="btn border-0 py-2 bg-maristred text-xl font-bold text-slate-50 hover:opacity-70"
+						on:click={() => (isEditing = true)}
+						>
+						<span
+							tabindex="0"
+							role="button"
+							class="text-slate-50 text-2xl material-symbols-outlined hover:cursor-pointer pr-2"
+							>
+							edit_note
+						</span>
+						Edit
+					</button>
+				{/if}
 			{/if}
 		</div>
 

--- a/src/lib/components/MarkAsSoldModal.svelte
+++ b/src/lib/components/MarkAsSoldModal.svelte
@@ -25,7 +25,7 @@
 			<option selected disabled value="">Buyer</option>
 			{#each buyerList as buyer}
 				<option value={JSON.stringify({
-					buyer,
+					...buyer,
 					item: itemID
 				})}>{buyer.username}</option>
 			{/each}

--- a/src/lib/components/MarkAsSoldModal.svelte
+++ b/src/lib/components/MarkAsSoldModal.svelte
@@ -20,7 +20,7 @@
 		class="flex justify-center w-full gap-4"
 		use:enhance={submitFunction}
 	>
-		<select name="buyer" class="w-1/3 text-center bg-maristgrey" required>
+		<select name="buyer" class="w-1/3 text-slate-950  text-center bg-maristgrey" required>
 			<option selected disabled value="">Buyer</option>
 			{#each buyerList as buyer}
 				<option value={JSON.stringify(buyer)}>{buyer.username}</option>

--- a/src/lib/components/MarkAsSoldModal.svelte
+++ b/src/lib/components/MarkAsSoldModal.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	export let buyerList: { username: string; id: string }[];
+</script>
+
+<div class="flex flex-col items-center gap-10 bg-maristred w-1/2 text-slate-50 h-max border p-5">
+	<div>
+		<h1 class="text-2xl text-center font-bold">
+			Ready to Sell? Please choose the buyer from the choices below:
+		</h1>
+		<h1 class="text-center">(Buyers are chosen from your current conversations)</h1>
+	</div>
+
+	<form action="" class="flex justify-center w-full gap-4">
+		<select name="buyer" class="w-1/3  text-center bg-maristgrey" required>
+			<option selected disabled value="">Buyer</option>
+			{#each buyerList as buyer}
+				<option value={buyer}>{buyer.username}</option>
+			{/each}
+		</select>
+
+		<button class="btn">Sell!</button>
+	</form>
+</div>

--- a/src/lib/components/MarkAsSoldModal.svelte
+++ b/src/lib/components/MarkAsSoldModal.svelte
@@ -4,6 +4,7 @@
 
 	export let buyerList: { username: string; id: string }[];
 	export let submitFunction: SubmitFunction;
+	export let itemID: string;
 </script>
 
 <div class="flex flex-col items-center gap-10 bg-maristred w-1/2 text-slate-50 h-max border p-5">
@@ -23,7 +24,10 @@
 		<select name="buyer" class="w-1/3 text-slate-950  text-center bg-maristgrey" required>
 			<option selected disabled value="">Buyer</option>
 			{#each buyerList as buyer}
-				<option value={JSON.stringify(buyer)}>{buyer.username}</option>
+				<option value={JSON.stringify({
+					buyer,
+					item: itemID
+				})}>{buyer.username}</option>
 			{/each}
 		</select>
 

--- a/src/lib/components/MarkAsSoldModal.svelte
+++ b/src/lib/components/MarkAsSoldModal.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { SubmitFunction } from '@sveltejs/kit';
+
 	export let buyerList: { username: string; id: string }[];
+	export let submitFunction: SubmitFunction;
 </script>
 
 <div class="flex flex-col items-center gap-10 bg-maristred w-1/2 text-slate-50 h-max border p-5">
@@ -10,11 +14,16 @@
 		<h1 class="text-center">(Buyers are chosen from your current conversations)</h1>
 	</div>
 
-	<form action="" class="flex justify-center w-full gap-4">
-		<select name="buyer" class="w-1/3  text-center bg-maristgrey" required>
+	<form
+		method="POST"
+		action="/items?/sell"
+		class="flex justify-center w-full gap-4"
+		use:enhance={submitFunction}
+	>
+		<select name="buyer" class="w-1/3 text-center bg-maristgrey" required>
 			<option selected disabled value="">Buyer</option>
 			{#each buyerList as buyer}
-				<option value={buyer}>{buyer.username}</option>
+				<option value={JSON.stringify(buyer)}>{buyer.username}</option>
 			{/each}
 		</select>
 

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -54,7 +54,7 @@
 		<img class="w-4/6 aspect-square" src={item.imageUrl} alt="" />
 	</div>
 	{#if isEditing}
-		<EditForm bind:isEditing {item} />
+		<EditForm bind:isEditing {item} buyerList={data.buyers} />
 	{:else}
 		<ListingInfoDisplay
 			{item}

--- a/src/routes/api/item/[item_id]/+server.ts
+++ b/src/routes/api/item/[item_id]/+server.ts
@@ -53,6 +53,14 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	}
 
 	try {
+		const currentItemInfo = await prisma.listing.findFirst({
+			where: {
+				id: itemID
+			}
+		});
+
+		if (currentItemInfo?.sold) return new Response(JSON.stringify({ message: 'Item is sold.' }), { status: 409 });
+
 		await prisma.listing.update({
 			where: {
 				id: itemID,

--- a/src/routes/api/item/[item_id]/buyers/+server.ts
+++ b/src/routes/api/item/[item_id]/buyers/+server.ts
@@ -1,0 +1,37 @@
+import prisma from "$lib/utils/prismaClient";
+import { json, type RequestHandler } from "@sveltejs/kit";
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	const { item_id } = params;
+	const userID = locals.data?.userID;
+
+	try {
+		const buyerChats = await prisma.chat.findMany({
+			where: {
+				itemId: item_id,
+				sellerId: userID
+			},
+			include: {
+				buyer: {
+					select: {
+						id: true,
+						username: true
+					}
+				}
+			}
+		});
+		const buyers = buyerChats.map((buyerChat) => {
+			return {
+				id: buyerChat.buyer.id,
+				username: buyerChat.buyer.username,
+			}
+		})
+
+		return json({ buyers });
+	} catch (error) {
+		const cleanError = (error as Error);
+
+		return new Response(JSON.stringify({message: cleanError.message}), {status: 500});
+	}
+};
+

--- a/src/routes/api/item/[item_id]/sell/+server.ts
+++ b/src/routes/api/item/[item_id]/sell/+server.ts
@@ -1,12 +1,27 @@
 import prisma from "$lib/utils/prismaClient";
 import { json, type RequestHandler } from "@sveltejs/kit";
 
-export const PATCH: RequestHandler = async ({ request }) => {
+export const PATCH: RequestHandler = async ({ request, params }) => {
+	// will use the buyer information in ratings, not rn though 
 	const data = await request.json();
+	const { item_id } = params;
 
-	// mark the item as sold here
-	console.log({ data });
+	try {
+		await prisma.listing.update({
+			where: {
+				id: item_id
+			},
+			data: {
+				sold: true
+			}
+		});
 
-	return json({});
+		return json({ message: "Item marked as sold" });
+	} catch (error) {
+		const cleanError = error as Error;
+
+		return new Response(JSON.stringify({ message: cleanError.message }), { status: 500 })
+	}
+
 };
 

--- a/src/routes/api/item/[item_id]/sell/+server.ts
+++ b/src/routes/api/item/[item_id]/sell/+server.ts
@@ -1,0 +1,12 @@
+import prisma from "$lib/utils/prismaClient";
+import { json, type RequestHandler } from "@sveltejs/kit";
+
+export const PATCH: RequestHandler = async ({ request }) => {
+	const data = await request.json();
+
+	// mark the item as sold here
+	console.log({ data });
+
+	return json({});
+};
+

--- a/src/routes/api/users/+server.ts
+++ b/src/routes/api/users/+server.ts
@@ -5,6 +5,7 @@
 import { json, error as failure } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import supabaseClient from '$lib/utils/supabaseClient';
+import prisma from '$lib/utils/prismaClient';
 
 export const POST: RequestHandler = async ({ request, cookies }) => {
 	// getting user info from request
@@ -35,6 +36,13 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			secure: true,
 			httpOnly: true,
 			path: '/',
+		});
+
+		await prisma.user.create({
+			data: {
+				id: data.user.id,
+				username
+			}
 		});
 	}
 

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -131,5 +131,12 @@ export const actions = {
 			method: "PATCH",
 			body: JSON.stringify(body)
 		});
+
+		if (response.ok) {
+			return { success: true }
+		}
+
+
+		return fail(response.status, { message: (await response.json()).message })
 	}
 } satisfies Actions;

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -124,10 +124,10 @@ export const actions = {
 	},
 	sell: async ({ request, fetch }) => {
 		const data = await request.formData();
-		const buyer = JSON.parse(data.get('buyer') as string) as { username: string, id: string, itemID: string };
+		const buyer = JSON.parse(data.get('buyer') as string) as { username: string, id: string, item: string };
 		const body = { buyerID: buyer.id, buyerUsername: buyer.username };
 
-		const response = await fetch(`/api/item/${buyer.itemID}/sell`, {
+		const response = await fetch(`/api/item/${buyer.item}/sell`, {
 			method: "PATCH",
 			body: JSON.stringify(body)
 		});

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -122,10 +122,14 @@ export const actions = {
 
 		return fail(400, { errors: [(await response.json()).message] });
 	},
-	sell: async ({ request }) => {
+	sell: async ({ request, fetch }) => {
 		const data = await request.formData();
-		const buyer = JSON.parse(data.get('buyer') as string) as { username: string, id: string };
+		const buyer = JSON.parse(data.get('buyer') as string) as { username: string, id: string, itemID: string };
+		const body = { buyerID: buyer.id, buyerUsername: buyer.username };
 
-		console.log({ buyer });
+		const response = await fetch(`/api/item/${buyer.itemID}/sell`, {
+			method: "PATCH",
+			body: JSON.stringify(body)
+		});
 	}
 } satisfies Actions;

--- a/src/routes/items/+page.server.ts
+++ b/src/routes/items/+page.server.ts
@@ -122,4 +122,10 @@ export const actions = {
 
 		return fail(400, { errors: [(await response.json()).message] });
 	},
+	sell: async ({ request }) => {
+		const data = await request.formData();
+		const buyer = JSON.parse(data.get('buyer') as string) as { username: string, id: string };
+
+		console.log({ buyer });
+	}
 } satisfies Actions;


### PR DESCRIPTION
Users can now mark items as sold. They can pick the person that they sold it to, and their options are pulled from all the buyers that initiated chats for that item.

Once an item is sold, the owner can no longer make edits to the listing, and the listing is removed from the feed.
